### PR TITLE
Feat: Main Page 구현

### DIFF
--- a/src/app/router/lazy.ts
+++ b/src/app/router/lazy.ts
@@ -1,3 +1,4 @@
 import { lazy } from 'react';
 
-export const MainPage = lazy(() => import('@page/main/main-page'));
+export const MainPage = lazy(() => import('@page/main-page'));
+export const MyPage = lazy(() => import('@page/my-page'));

--- a/src/app/router/path.ts
+++ b/src/app/router/path.ts
@@ -1,5 +1,6 @@
 export const routePath = {
   MAIN: '/',
+  MY: '/MY',
 } as const;
 
 export type Routes = (typeof routePath)[keyof typeof routePath];

--- a/src/app/router/routes/global-routes.tsx
+++ b/src/app/router/routes/global-routes.tsx
@@ -1,9 +1,13 @@
 import { routePath } from '@app/router/path';
-import { MainPage } from '@app/router/lazy';
+import { MainPage, MyPage } from '@app/router/lazy';
 
 export const globalRoutes = [
   {
     path: routePath.MAIN,
     element: <MainPage />,
+  },
+  {
+    path: '/my',
+    element: <MyPage />,
   },
 ];

--- a/src/page/main-page.tsx
+++ b/src/page/main-page.tsx
@@ -1,0 +1,140 @@
+import { TopNavigation } from '@shared/ui/topNavigation';
+import UserIcon from '@shared/assets/icon/user.svg?react';
+import BellIcon from '@shared/assets/icon/bell.svg?react';
+import { DropButton } from '@widgets/main/dropBotton';
+import { useState } from 'react';
+import BottomSheet from '@widgets/main/bottom-sheet/bottom-sheet';
+import { BottomSheetLocationSearch } from '@widgets/main/bottom-sheet/contents/bottom-sheet-location-search';
+import { RadioContent } from '@widgets/main/bottom-sheet/contents/radio/radio-content';
+import { Card } from '@widgets/main/card/card';
+import { NotificationPanel } from '@widgets/main/notification/notificationPanel';
+import { useNavigate } from 'react-router';
+
+export type SortType = 'latest' | 'near';
+type SheetType = 'location' | 'sort' | null;
+
+const mockCards = [
+  {
+    id: 1,
+    image: 'https://via.placeholder.com/102x128',
+    title: '역삼동 공터에서 경도 할 사람 찾고 있어요!! (성인만)',
+    date: '01.01 / 13:40',
+    count: '1 / 20',
+    location: '개나리 공원',
+  },
+  {
+    id: 2,
+    image: 'https://via.placeholder.com/102x128',
+    title: '주말에 같이 운동하실 분 구합니다',
+    date: '01.02 / 10:00',
+    count: '3 / 10',
+    location: '역삼 체육관',
+  },
+];
+const mockNotifications = [
+  {
+    value:
+      '“역삼동 공터에서 경도하실 분 찾아요!” 게임에서 참가가 확정되었습니다.',
+    time: '방금 전',
+  },
+  {
+    value:
+      '“역삼동 공터에서 경도하실 분 찾아요!” 게임에서 참가가 확정되었습니다.',
+    time: '10분 전',
+  },
+];
+
+const MainPage = () => {
+  const navigate = useNavigate();
+  const [location, setLocation] = useState('');
+  const [sortType, setSortType] = useState<SortType>('latest');
+  const [openSheet, setOpenSheet] = useState<SheetType>(null);
+  const [isNotificationOpen, setIsNotificationOpen] = useState(false);
+  return (
+    <div>
+      <TopNavigation
+        leftIcon={<UserIcon width="2.4rem" height="2.4rem" />}
+        rightIcon={<BellIcon width="2.4rem" height="2.4rem" />}
+        onLeftClick={() => navigate('/my')}
+        onRightClick={() => setIsNotificationOpen((prev) => !prev)}
+      />
+      {isNotificationOpen && (
+        <>
+          <div
+            className="fixed inset-0 z-40"
+            onClick={() => setIsNotificationOpen(false)}
+          />
+          <div
+            className="absolute right-[2.4rem] top-[5.6rem] z-50"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <NotificationPanel notifications={mockNotifications} />
+          </div>
+        </>
+      )}
+      <div className="flex flex-col gap-[0.8rem] px-[2.4rem] pb-[0.4rem]">
+        <span className="text-gray-600 typo-h3 h-[2.2rem]">
+          오늘도 안전한 하루 되세요!
+        </span>
+        <p className="typo-h1">방 찾기</p>
+      </div>
+      <div className="flex px-[2.4rem] gap-[1.2rem] py-[2rem]">
+        <DropButton
+          label={location || '위치 선택'}
+          onClick={() => setOpenSheet('location')}
+        />
+        <DropButton
+          label={sortType === 'latest' ? '최신순' : '가까운 순'}
+          onClick={() => setOpenSheet('sort')}
+        />
+      </div>
+      <div className="flex flex-col gap-[2rem] items-center">
+        {mockCards.map((card) => (
+          <Card
+            key={card.id}
+            image={card.image}
+            title={card.title}
+            date={card.date}
+            count={card.count}
+            location={card.location}
+          />
+        ))}
+      </div>
+      <BottomSheet.Root
+        isOpen={openSheet !== null}
+        onClose={() => setOpenSheet(null)}
+      >
+        <BottomSheet.Overlay />
+
+        <BottomSheet.Container size={openSheet === 'location' ? 'md' : 'sm'}>
+          {openSheet === 'location' && (
+            <>
+              <BottomSheet.Header title="위치 설정" />
+              <BottomSheet.Content>
+                <BottomSheetLocationSearch
+                  value={location}
+                  onChange={setLocation}
+                />
+              </BottomSheet.Content>
+            </>
+          )}
+          {openSheet === 'sort' && (
+            <>
+              <BottomSheet.Header title="정렬" />
+              <BottomSheet.Content>
+                <RadioContent
+                  value={sortType}
+                  onChange={(next) => {
+                    setSortType(next);
+                    setOpenSheet(null);
+                  }}
+                />
+              </BottomSheet.Content>
+            </>
+          )}
+        </BottomSheet.Container>
+      </BottomSheet.Root>
+    </div>
+  );
+};
+export default MainPage;

--- a/src/page/main/main-page.tsx
+++ b/src/page/main/main-page.tsx
@@ -1,4 +1,0 @@
-const MainPage = () => {
-  return <div>mainPage</div>;
-};
-export default MainPage;

--- a/src/page/my-page.tsx
+++ b/src/page/my-page.tsx
@@ -1,0 +1,4 @@
+const MyPage = () => {
+  return <div>myPage</div>;
+};
+export default MyPage;

--- a/src/shared/ui/topNavigation.tsx
+++ b/src/shared/ui/topNavigation.tsx
@@ -3,13 +3,21 @@ import type { ReactNode } from 'react';
 interface TopNavigationProps {
   leftIcon?: ReactNode;
   rightIcon?: ReactNode;
+  onLeftClick?: () => void;
+  onRightClick?: () => void;
 }
 
-export function TopNavigation({ leftIcon, rightIcon }: TopNavigationProps) {
+export function TopNavigation({
+  leftIcon,
+  rightIcon,
+  onLeftClick,
+  onRightClick,
+}: TopNavigationProps) {
   return (
-    <div className="flex items-center justify-between w-full h-[6.4rem] p-[2.4rem]">
-      <button>{leftIcon}</button>
-      <button>{rightIcon}</button>
+    <div className="flex items-center justify-between w-full h-[6.4rem] px-[2rem] py-[2.4rem]">
+      <button onClick={onLeftClick}>{leftIcon}</button>
+
+      <button onClick={onRightClick}>{rightIcon}</button>
     </div>
   );
 }

--- a/src/widgets/main/bottom-sheet/bottom-sheet.tsx
+++ b/src/widgets/main/bottom-sheet/bottom-sheet.tsx
@@ -15,12 +15,7 @@ interface BottomSheetProps {
 function Overlay() {
   const { onClose } = useBottomSheetContext();
 
-  return (
-    <div
-      onClick={onClose}
-      className="fixed inset-0 bg-black/30 backdrop-blur"
-    />
-  );
+  return <div onClick={onClose} className="fixed inset-0 bg-black/30" />;
 }
 
 function Root({ isOpen, onClose, children }: BottomSheetProps) {

--- a/src/widgets/main/bottom-sheet/contents/bottom-sheet-location-search.tsx
+++ b/src/widgets/main/bottom-sheet/contents/bottom-sheet-location-search.tsx
@@ -2,12 +2,15 @@ import { FloatingActionButton } from '@shared/ui/floatingActionButton';
 import Input from '@shared/ui/input';
 import LocationIcon from '@shared/assets/icon/material-symbols_my-location-outline-rounded.svg?react';
 
-interface LocationSearchProps {
+interface BottomSheetLocationSearchProps {
   value: string;
   onChange: (value: string) => void;
 }
 
-export function LocationSearch({ value, onChange }: LocationSearchProps) {
+export function BottomSheetLocationSearch({
+  value,
+  onChange,
+}: BottomSheetLocationSearchProps) {
   return (
     <div className="flex items-center justify-center h-[9.2rem] gap-[1.6rem]">
       <Input

--- a/src/widgets/main/dropBotton.tsx
+++ b/src/widgets/main/dropBotton.tsx
@@ -6,7 +6,7 @@ interface DropButtonProps {
 
 export function DropButton({ label, onClick }: DropButtonProps) {
   return (
-    <button className="flex w-[8.9rem] h-[4rem] items-center justify-center border border-gray-200 rounded-[12px] gap-[0.4rem]">
+    <button className="flex px-[1.2rem] h-[4rem] items-center justify-center border border-gray-200 rounded-[12px] gap-[0.4rem]">
       <span className="typo-body1">{label}</span>
       <ChevronDown onClick={onClick} width={'2rem'} height={'2rem'} />
     </button>

--- a/src/widgets/main/notification/notificationPanel.tsx
+++ b/src/widgets/main/notification/notificationPanel.tsx
@@ -9,7 +9,7 @@ interface NotificationPanelProps {
 
 export function NotificationPanel({ notifications }: NotificationPanelProps) {
   return (
-    <div className="w-[30rem] px-[1.2rem] h-[30.6rem] border border-gray-200 rounded-[12px]">
+    <div className="w-[30rem] px-[1.2rem] h-[30.6rem] bg-white border border-gray-200 rounded-[12px]">
       <div className="flex h-[5.4rem] justify-between">
         <span className="w-[6.4rem] h-[2.2rem] pt-[1.2rem] typo-h3">
           알림 내역


### PR DESCRIPTION
## 📌 Summary

> - #47 
- TopNavigation, DropButton, Card 등 공통 컴포넌트를 활용해 메인 페이지 레이아웃 구현
- 위치 선택 / 정렬 선택을 BottomSheet 기반으로 분리하여 인터랙션 구현
- 알림 아이콘 클릭 시 NotificationPanel 노출되도록 구성
- 추후 API 연동을 고려해 카드/알림 데이터는 mock 데이터로 렌더링
## 📚 Tasks

뭔가 분기도 하나 밖에 안들어가 있는데 컴파운드 패턴이 많아서 그런지 파일이 좀 길어지네요 api 연결 말고는 mainpage 모두 구현 했습니다.

<!--
## 🙋🏻‍♂️ Request
리뷰어 혹은 팀에게 요청하고 싶은 사항이 있다면 작성해 주세요.
-->


## 📸 Screenshot
해당 작업에 대한 스크린샷 및 자료를 첨부해 주세요.
<img width="425" height="592" alt="image" src="https://github.com/user-attachments/assets/67b89208-8eec-49f3-85cc-988ee3a9964f" />
<img width="425" height="592" alt="image" src="https://github.com/user-attachments/assets/cf6e7247-3e6b-4ddc-a3ba-b4b646111319" />
